### PR TITLE
onClick plutôt que form action

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
 
 <body>
   <canvas id="Canvas" width="400" height="400"></canvas>
-  <form action="/html/tags/html_form_tag_action.cfm" method="post">
+  <div>
     Insert Text<br />
     <textarea name="comments" id="comments">
-</textarea><br />
-    <input type="Submit" value="Submit" />
-  </form>
+    </textarea><br />
+    <input type="Submit" value="Submit" onclick="submit();" />
+  </div>
   <script src="script.js"></script>
 </body>
 

--- a/script.js
+++ b/script.js
@@ -33,3 +33,15 @@ if (randomShape == 1) {
     context.strokeStyle = '#000';
     context.stroke();
 }
+
+
+function submit() {
+
+    var textfield = document.getElementById("comments");
+    var text = textfield.value;
+
+    context.font = "30px Arial";
+    context.fillText(text, 10, 50);
+  
+  }
+  


### PR DESCRIPTION
Les "form action" nécessitent un traitement côté serveur, pas possible avec Github Pages.

On utilise donc un événement javascript (onClick), et on récupère le contenu de la zone de texte.